### PR TITLE
bugfix - splitTables() attempted to preg_match an array. Added is_array.

### DIFF
--- a/src/Jasny/MySQL/DBQuery.php
+++ b/src/Jasny/MySQL/DBQuery.php
@@ -8,6 +8,8 @@ require_once __DIR__ . '/DBQuery/Splitter.php';
  * Query builder for MySQL query statements.
  * All editing statements support fluent interfaces.
  * 
+ * @method static DBQuery select()
+ *
  * @package DBQuery
  */
 class DBQuery

--- a/src/Jasny/MySQL/DBQuery/Splitter.php
+++ b/src/Jasny/MySQL/DBQuery/Splitter.php
@@ -660,8 +660,10 @@ class DBQuery_Splitter
      */
     public static function splitTables($sql)
     {
+		if(!is_array($sql) && self::getQueryType($sql)) $parts = self::split($sql);
+		else $parts = $sql;
+		
         if (is_array($sql) || self::getQueryType($sql)) {
-            $parts = self::split($sql);
             if (array_key_exists('from', $parts)) $sql = & $parts['from'];
             elseif (array_key_exists('table', $parts)) $sql = & $parts['table'];
             elseif (array_key_exists('into', $parts)) $sql = & $parts['into'];


### PR DESCRIPTION
Was unable to call getTables() because, internally, splitTables sent an array to be preg_match-ed.
Fix: if object is an array, just use it as is. Otherwise, send it to be matched/split/whatever.
